### PR TITLE
Prevent message loops on FDC3 channels

### DIFF
--- a/src/services/FDC3/FDC3Service.ts
+++ b/src/services/FDC3/FDC3Service.ts
@@ -19,7 +19,6 @@ DialogManager.createStore(() => { });
 import DesktopAgent from './desktopAgent'
 // const queryJSON = require('./objectQuery/queryJSON.js');
 
-
 Logger.log("Desktop Agent starting up");
 
 /**
@@ -28,162 +27,162 @@ Logger.log("Desktop Agent starting up");
  */
 
 class FDC3Service extends BaseService {
-  desktopAgent: DesktopAgent;
-  channels: { [key: string]: Channel } = {};
+	desktopAgent: DesktopAgent;
+	channels: { [key: string]: Channel } = {};
 
-  constructor(params: {
-    name: string; startupDependencies: {
-      services: string[]; clients: string[];
-    };
-  }) {
-    super(params);
-    this.initialize = this.initialize.bind(this);
-    this.onBaseServiceReady(this.initialize);
-    this.start();
-  }
+	constructor(params: {
+		name: string; startupDependencies: {
+			services: string[]; clients: string[];
+		};
+	}) {
+		super(params);
+		this.initialize = this.initialize.bind(this);
+		this.onBaseServiceReady(this.initialize);
+		this.start();
+	}
 	/**
 	 * Initializes service variables
 	 * @private
 	 */
-  async initialize(cb: () => void) {
-    this.createRouterEndpoints();
-    Finsemble.Clients.Logger.log("desktopAgent Service ready");
-    this.desktopAgent = new DesktopAgent({
-      FSBL: Finsemble,
-    })
-    const channels = await this.desktopAgent.getSystemChannels();
-    for (const channel of channels) {
-      this.channels[channel.id] = channel;
-    }
-    cb();
-  }
+	async initialize(cb: () => void) {
+		this.createRouterEndpoints();
+		Finsemble.Clients.Logger.log("desktopAgent Service ready");
+		this.desktopAgent = new DesktopAgent({
+			FSBL: Finsemble,
+		})
+		const channels = await this.desktopAgent.getSystemChannels();
+		for (const channel of channels) {
+			this.channels[channel.id] = channel;
+		}
+		cb();
+	}
 
 	/**
 	 * Creates router endpoints for all of our client APIs. Add servers or listeners for requests coming from your clients.
 	 * @private
 	 */
-  createRouterEndpoints() {
-    const DesktopAgentApiList = [
-      "addContextListener",
-      "addIntentListener",
-      "broadcast",
-      "findIntent",
-      "findIntentsByContext",
-      "getCurrentChannel",
-      "getOrCreateChannel",
-      "getSystemChannels",
-      "joinChannel",
-      "leaveCurrentChannel",
-      "open",
-      "raiseIntent"
-    ];
+	createRouterEndpoints() {
+		const DesktopAgentApiList = [
+			"addContextListener",
+			"addIntentListener",
+			"broadcast",
+			"findIntent",
+			"findIntentsByContext",
+			"getCurrentChannel",
+			"getOrCreateChannel",
+			"getSystemChannels",
+			"joinChannel",
+			"leaveCurrentChannel",
+			"open",
+			"raiseIntent"
+		];
 
-    for (const ApiCall of DesktopAgentApiList) {
-      RouterClient.addResponder(`FDC3.DesktopAgent.${ApiCall}`, async (err: Error, queryMessage: any) => {
-        // TODO: Discuss this hack vs alternates:
-        // 1. One DesktopAgent per window (this is problematic because need to wrap windows, keep track of closing etc. otherwise will run into workspace issues)
-        // 2. Dynamically create a new DesktopAgent each use
-        // 3. Do some things completely in the client
-        this.desktopAgent.windowName = (queryMessage.header.origin as string).replace("RouterClient.", "");
+		for (const ApiCall of DesktopAgentApiList) {
+			RouterClient.addResponder(`FDC3.DesktopAgent.${ApiCall}`, async (err: Error, queryMessage: any) => {
+				// TODO: Discuss this hack vs alternates:
+				// 1. One DesktopAgent per window (this is problematic because need to wrap windows, keep track of closing etc. otherwise will run into workspace issues)
+				// 2. Dynamically create a new DesktopAgent each use
+				// 3. Do some things completely in the client
+				this.desktopAgent.windowName = (queryMessage.header.origin as string).replace("RouterClient.", "");
 
-        try {
-          let response;
-          switch (ApiCall) {
-            case "addContextListener":
-              response = await this.desktopAgent.addContextListener(queryMessage.data.contextType, () => {
-                // TODO
-              })
-              break;
-            case "addIntentListener":
-              response = await this.desktopAgent.addIntentListener(queryMessage.data.intent, () => {
-                // TODO
-              })
-              break;
-            case "broadcast":
-              response = await this.desktopAgent.broadcast(queryMessage.data.context);
-              break;
-            case "findIntent":
-              response = await this.desktopAgent.findIntent(queryMessage.data.intent, queryMessage.data.context);
-              break;
-            case "findIntentsByContext":
-              response = await this.desktopAgent.findIntentsByContext(queryMessage.data.context);
-              break;
-            case "getCurrentChannel":
-              response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
-              break;
-            case "getOrCreateChannel":
-              response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
-              this.channels[queryMessage.data.channelId] = response;
-              break;
-            case "getSystemChannels":
-              response = await this.desktopAgent.getSystemChannels();
-              break;
-            case "joinChannel":
-              response = await this.desktopAgent.joinChannel(queryMessage.data.channelId);
-              break;
-            case "leaveCurrentChannel":
-              // This wasn't in the interface but is present in the documentation.
-              throw new Error("leaveCurrentChannel is not implemented.");
-              break;
-            case "open":
-              response = await this.desktopAgent.open(queryMessage.data.name, queryMessage.data.context);
-              break;
-            case "raiseIntent":
-              response = await this.desktopAgent.raiseIntent(queryMessage.data.intent, queryMessage.data.context);
-              break;
-          }
-          queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
-        } catch (err) {
-          queryMessage.sendQueryResponse(err, null);
-        }
-      })
-    }
+				try {
+					let response;
+					switch (ApiCall) {
+						case "addContextListener":
+							response = await this.desktopAgent.addContextListener(queryMessage.data.contextType, () => {
+								// TODO
+							})
+							break;
+						case "addIntentListener":
+							response = await this.desktopAgent.addIntentListener(queryMessage.data.intent, () => {
+								// TODO
+							})
+							break;
+						case "broadcast":
+							response = await this.desktopAgent.broadcast(queryMessage.data.context);
+							break;
+						case "findIntent":
+							response = await this.desktopAgent.findIntent(queryMessage.data.intent, queryMessage.data.context);
+							break;
+						case "findIntentsByContext":
+							response = await this.desktopAgent.findIntentsByContext(queryMessage.data.context);
+							break;
+						case "getCurrentChannel":
+							response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
+							break;
+						case "getOrCreateChannel":
+							response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
+							this.channels[queryMessage.data.channelId] = response;
+							break;
+						case "getSystemChannels":
+							response = await this.desktopAgent.getSystemChannels();
+							break;
+						case "joinChannel":
+							response = await this.desktopAgent.joinChannel(queryMessage.data.channelId);
+							break;
+						case "leaveCurrentChannel":
+							// This wasn't in the interface but is present in the documentation.
+							throw new Error("leaveCurrentChannel is not implemented.");
+							break;
+						case "open":
+							response = await this.desktopAgent.open(queryMessage.data.name, queryMessage.data.context);
+							break;
+						case "raiseIntent":
+							response = await this.desktopAgent.raiseIntent(queryMessage.data.intent, queryMessage.data.context);
+							break;
+					}
+					queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
+				} catch (err) {
+					queryMessage.sendQueryResponse(err, null);
+				}
+			})
+		}
 
-    const ChannelApiList = [
-      "addContextListener",
-      "broadcast",
-      "getCurrentContext"
-    ];
+		const ChannelApiList = [
+			"addContextListener",
+			"broadcast",
+			"getCurrentContext"
+		];
 
-    for (const ApiCall of ChannelApiList) {
-      RouterClient.addResponder(`FDC3.Channel.${ApiCall}`, async (err: Error, queryMessage: any) => {
-        try {
-          const channel = this.channels[queryMessage.data.channel]
-          if (!channel) throw Error('Channel not found')
-          let response;
-          switch (ApiCall) {
-            case "addContextListener":
-              response = await channel.addContextListener(queryMessage.data.contextType, () => {
-                // TODO
-              })
-              break;
-            case "broadcast":
-              response = await channel.broadcast(queryMessage.data);
-              break;
-            case "getCurrentContext":
-              response = await channel.getCurrentContext(queryMessage.data.contextType);
-              break;
-          }
-          queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
-        } catch (err) {
-          queryMessage.sendQueryResponse(err, null);
-        }
-      })
-    }
-  }
+		for (const ApiCall of ChannelApiList) {
+			RouterClient.addResponder(`FDC3.Channel.${ApiCall}`, async (err: Error, queryMessage: any) => {
+				try {
+					const channel = this.channels[queryMessage.data.channel]
+					if (!channel) throw Error('Channel not found')
+					let response;
+					switch (ApiCall) {
+						case "addContextListener":
+							response = await channel.addContextListener(queryMessage.data.contextType, () => {
+								// TODO
+							})
+							break;
+						case "broadcast":
+							response = await channel.broadcast(queryMessage.data);
+							break;
+						case "getCurrentContext":
+							response = await channel.getCurrentContext(queryMessage.data.contextType);
+							break;
+					}
+					queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
+				} catch (err) {
+					queryMessage.sendQueryResponse(err, null);
+				}
+			})
+		}
+	}
 
 }
 
 
 const serviceInstance = new
-  FDC3Service({
-    name: "FDC3",
-    startupDependencies: {
-      // add any services or clients that should be started before your service
-      services: ["authenticationService"],
-      clients: []
-    }
-  });
+	FDC3Service({
+		name: "FDC3",
+		startupDependencies: {
+			// add any services or clients that should be started before your service
+			services: ["authenticationService"],
+			clients: []
+		}
+	});
 
 serviceInstance.start();
 module.exports = serviceInstance;

--- a/src/services/FDC3/FDC3Service.ts
+++ b/src/services/FDC3/FDC3Service.ts
@@ -7,13 +7,13 @@ const Finsemble = require("@chartiq/finsemble");
 const BaseService = Finsemble.baseService;
 const { RouterClient, LinkerClient, DialogManager, WindowClient, LauncherClient, DistributedStoreClient, Logger } = Finsemble.Clients;
 
-LinkerClient.start(()=>{});
+LinkerClient.start(() => { });
 DialogManager.initialize();
 LauncherClient.initialize();
 Logger.start();
 WindowClient.initialize();
 DistributedStoreClient.initialize();
-DialogManager.createStore(()=>{});
+DialogManager.createStore(() => { });
 
 
 import DesktopAgent from './desktopAgent'
@@ -28,162 +28,162 @@ Logger.log("Desktop Agent starting up");
  */
 
 class FDC3Service extends BaseService {
-	desktopAgent: DesktopAgent;
-	channels: { [key: string]: Channel } = {};
+  desktopAgent: DesktopAgent;
+  channels: { [key: string]: Channel } = {};
 
-	constructor(params: {
-		name: string; startupDependencies: {
-			services: string[]; clients: string[];
-		};
-	}) {
-		super(params);
-		this.initialize = this.initialize.bind(this);
-		this.onBaseServiceReady(this.initialize);
-		this.start();
-	}
+  constructor(params: {
+    name: string; startupDependencies: {
+      services: string[]; clients: string[];
+    };
+  }) {
+    super(params);
+    this.initialize = this.initialize.bind(this);
+    this.onBaseServiceReady(this.initialize);
+    this.start();
+  }
 	/**
 	 * Initializes service variables
 	 * @private
 	 */
-	async initialize(cb: () => void) {
-		this.createRouterEndpoints();
-		Finsemble.Clients.Logger.log("desktopAgent Service ready");
-		this.desktopAgent = new DesktopAgent({
-			FSBL: Finsemble,
-		})
-		const channels = await this.desktopAgent.getSystemChannels();
-		for (const channel of channels) {
-			this.channels[channel.id] = channel;
-		}
-		cb();
-	}
+  async initialize(cb: () => void) {
+    this.createRouterEndpoints();
+    Finsemble.Clients.Logger.log("desktopAgent Service ready");
+    this.desktopAgent = new DesktopAgent({
+      FSBL: Finsemble,
+    })
+    const channels = await this.desktopAgent.getSystemChannels();
+    for (const channel of channels) {
+      this.channels[channel.id] = channel;
+    }
+    cb();
+  }
 
 	/**
 	 * Creates router endpoints for all of our client APIs. Add servers or listeners for requests coming from your clients.
 	 * @private
 	 */
-	createRouterEndpoints() {
-		const DesktopAgentApiList = [
-			"addContextListener",
-			"addIntentListener",
-			"broadcast",
-			"findIntent",
-			"findIntentsByContext",
-			"getCurrentChannel",
-			"getOrCreateChannel",
-			"getSystemChannels",
-			"joinChannel",
-			"leaveCurrentChannel",
-			"open",
-			"raiseIntent"
-		];
+  createRouterEndpoints() {
+    const DesktopAgentApiList = [
+      "addContextListener",
+      "addIntentListener",
+      "broadcast",
+      "findIntent",
+      "findIntentsByContext",
+      "getCurrentChannel",
+      "getOrCreateChannel",
+      "getSystemChannels",
+      "joinChannel",
+      "leaveCurrentChannel",
+      "open",
+      "raiseIntent"
+    ];
 
-		for (const ApiCall of DesktopAgentApiList) {
-			RouterClient.addResponder(`FDC3.DesktopAgent.${ApiCall}`, async (err: Error, queryMessage: any) => {
-				// TODO: Discuss this hack vs alternates:
-				// 1. One DesktopAgent per window (this is problematic because need to wrap windows, keep track of closing etc. otherwise will run into workspace issues)
-				// 2. Dynamically create a new DesktopAgent each use
-				// 3. Do some things completely in the client
-				this.desktopAgent.windowName = (queryMessage.header.origin as string).replace("RouterClient.", "");
+    for (const ApiCall of DesktopAgentApiList) {
+      RouterClient.addResponder(`FDC3.DesktopAgent.${ApiCall}`, async (err: Error, queryMessage: any) => {
+        // TODO: Discuss this hack vs alternates:
+        // 1. One DesktopAgent per window (this is problematic because need to wrap windows, keep track of closing etc. otherwise will run into workspace issues)
+        // 2. Dynamically create a new DesktopAgent each use
+        // 3. Do some things completely in the client
+        this.desktopAgent.windowName = (queryMessage.header.origin as string).replace("RouterClient.", "");
 
-				try {
-					let response;
-					switch (ApiCall) {
-						case "addContextListener":
-							response = await this.desktopAgent.addContextListener(queryMessage.data.contextType, () => {
-								// TODO
-							})
-							break;
-						case "addIntentListener":
-							response = await this.desktopAgent.addIntentListener(queryMessage.data.intent, () => {
-								// TODO
-							})
-							break;
-						case "broadcast":
-							response = await this.desktopAgent.broadcast(queryMessage.data.context);
-							break;
-						case "findIntent":
-							response = await this.desktopAgent.findIntent(queryMessage.data.intent, queryMessage.data.context);
-							break;
-						case "findIntentsByContext":
-							response = await this.desktopAgent.findIntentsByContext(queryMessage.data.context);
-							break;
-						case "getCurrentChannel":
-							response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
-							break;
-						case "getOrCreateChannel":
-							response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
-							this.channels[queryMessage.data.channelId] = response;
-							break;
-						case "getSystemChannels":
-							response = await this.desktopAgent.getSystemChannels();
-							break;
-						case "joinChannel":
-							response = await this.desktopAgent.joinChannel(queryMessage.data.channelId);
-							break;
-						case "leaveCurrentChannel":
-							// This wasn't in the interface but is present in the documentation.
-							throw new Error("leaveCurrentChannel is not implemented.");
-							break;
-						case "open":
-							response = await this.desktopAgent.open(queryMessage.data.name, queryMessage.data.context);
-							break;
-						case "raiseIntent":
-							response = await this.desktopAgent.raiseIntent(queryMessage.data.intent, queryMessage.data.context);
-							break;
-					}
-					queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
-				} catch (err) {
-					queryMessage.sendQueryResponse(err, null);
-				}
-			})
-		}
+        try {
+          let response;
+          switch (ApiCall) {
+            case "addContextListener":
+              response = await this.desktopAgent.addContextListener(queryMessage.data.contextType, () => {
+                // TODO
+              })
+              break;
+            case "addIntentListener":
+              response = await this.desktopAgent.addIntentListener(queryMessage.data.intent, () => {
+                // TODO
+              })
+              break;
+            case "broadcast":
+              response = await this.desktopAgent.broadcast(queryMessage.data.context);
+              break;
+            case "findIntent":
+              response = await this.desktopAgent.findIntent(queryMessage.data.intent, queryMessage.data.context);
+              break;
+            case "findIntentsByContext":
+              response = await this.desktopAgent.findIntentsByContext(queryMessage.data.context);
+              break;
+            case "getCurrentChannel":
+              response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
+              break;
+            case "getOrCreateChannel":
+              response = await this.desktopAgent.getOrCreateChannel(queryMessage.data.channelId);
+              this.channels[queryMessage.data.channelId] = response;
+              break;
+            case "getSystemChannels":
+              response = await this.desktopAgent.getSystemChannels();
+              break;
+            case "joinChannel":
+              response = await this.desktopAgent.joinChannel(queryMessage.data.channelId);
+              break;
+            case "leaveCurrentChannel":
+              // This wasn't in the interface but is present in the documentation.
+              throw new Error("leaveCurrentChannel is not implemented.");
+              break;
+            case "open":
+              response = await this.desktopAgent.open(queryMessage.data.name, queryMessage.data.context);
+              break;
+            case "raiseIntent":
+              response = await this.desktopAgent.raiseIntent(queryMessage.data.intent, queryMessage.data.context);
+              break;
+          }
+          queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
+        } catch (err) {
+          queryMessage.sendQueryResponse(err, null);
+        }
+      })
+    }
 
-		const ChannelApiList = [
-			"addContextListener",
-			"broadcast",
-			"getCurrentContext"
-		];
+    const ChannelApiList = [
+      "addContextListener",
+      "broadcast",
+      "getCurrentContext"
+    ];
 
-		for (const ApiCall of ChannelApiList) {
-			RouterClient.addResponder(`FDC3.Channel.${ApiCall}`, async (err: Error, queryMessage: any) => {
-				try {
-					const channel = this.channels[queryMessage.data.channel]
-					if (!channel) throw Error('Channel not found')
-					let response;
-					switch (ApiCall) {
-						case "addContextListener":
-							response = await channel.addContextListener(queryMessage.data.contextType, () => {
-								// TODO
-							})
-							break;
-						case "broadcast":
-							response = await channel.broadcast(queryMessage.data.context);
-							break;
-						case "getCurrentContext":
-							response = await channel.getCurrentContext(queryMessage.data.contextType);
-							break;
-					}
-					queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
-				} catch (err) {
-					queryMessage.sendQueryResponse(err, null);
-				}
-			})
-		}
-	}
+    for (const ApiCall of ChannelApiList) {
+      RouterClient.addResponder(`FDC3.Channel.${ApiCall}`, async (err: Error, queryMessage: any) => {
+        try {
+          const channel = this.channels[queryMessage.data.channel]
+          if (!channel) throw Error('Channel not found')
+          let response;
+          switch (ApiCall) {
+            case "addContextListener":
+              response = await channel.addContextListener(queryMessage.data.contextType, () => {
+                // TODO
+              })
+              break;
+            case "broadcast":
+              response = await channel.broadcast(queryMessage.data);
+              break;
+            case "getCurrentContext":
+              response = await channel.getCurrentContext(queryMessage.data.contextType);
+              break;
+          }
+          queryMessage.sendQueryResponse(null, JSON.parse(JSON.stringify(response)));
+        } catch (err) {
+          queryMessage.sendQueryResponse(err, null);
+        }
+      })
+    }
+  }
 
 }
 
 
 const serviceInstance = new
-	FDC3Service({
-		name: "FDC3",
-		startupDependencies: {
-			// add any services or clients that should be started before your service
-			services: ["authenticationService"],
-			clients: []
-		}
-	});
+  FDC3Service({
+    name: "FDC3",
+    startupDependencies: {
+      // add any services or clients that should be started before your service
+      services: ["authenticationService"],
+      clients: []
+    }
+  });
 
 serviceInstance.start();
 module.exports = serviceInstance;

--- a/src/services/FDC3/channelClient.ts
+++ b/src/services/FDC3/channelClient.ts
@@ -19,7 +19,8 @@ export default class C implements Channel {
 
     broadcast(context: object): void {
         this.#FSBL.Clients.RouterClient.query("FDC3.Channel.broadcast", {
-            channel: this.id,
+			source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
+			channel: this.id,
             context
         }, () => { });
     }
@@ -39,6 +40,51 @@ export default class C implements Channel {
     addContextListener(handler: ContextHandler): Listener;
     addContextListener(contextType: string, handler: ContextHandler): Listener;
     addContextListener(contextTypeOrHandler: string | ContextHandler, handler?: ContextHandler): Listener {
+		let theHandler: ContextHandler = null;
+		let theListenerName: string = null;
+
+		//disambiguate arguments
+		if (typeof contextTypeOrHandler === "string") {
+			theHandler = handler;
+			theListenerName = `FDC3.broadcast.${contextTypeOrHandler}`
+		} else {
+			theHandler = contextTypeOrHandler;
+			theListenerName = `FDC3.broadcast`;
+		}
+
+		if (this.id == "global") {
+			const routerHandler: StandardCallback = (err, response) => {
+				//prevent message loops
+				if (response.data.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
+					//delete response.data.source // delete non standard source field we added
+					theHandler(response.data);
+				}
+			};
+			this.#FSBL.Clients.RouterClient.addListener(theListenerName, routerHandler);
+			return {
+				unsubscribe: () => {
+					this.#FSBL.Clients.RouterClient.removeListener(theListenerName, routerHandler);
+				}
+			}
+		} else {
+			const linkerHandler: StandardCallback = (err, response) => {
+				//prevent message loops
+				if (response.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
+					//delete response.source // delete non standard source field we added
+					theHandler(response);
+				}
+			};
+			this.#FSBL.Clients.LinkerClient.linkToChannel(this.id, this.#FSBL.Clients.WindowClient.getWindowIdentifier());
+			this.#FSBL.Clients.LinkerClient.subscribe(theListenerName, linkerHandler);
+			return {
+				unsubscribe: () => {
+					this.#FSBL.Clients.LinkerClient.unsubscribe(theListenerName, linkerHandler);
+				}
+			}
+		}
+
+
+
         if (this.id == "global") {
             if (typeof contextTypeOrHandler === "string") { // context type specified
                 const routerHandler: StandardCallback = (err, response) => { handler(response.data) };

--- a/src/services/FDC3/channelClient.ts
+++ b/src/services/FDC3/channelClient.ts
@@ -1,87 +1,87 @@
 declare global {
-	interface Window {
-		FSBL: typeof FSBL
-	}
+  interface Window {
+    FSBL: typeof FSBL
+  }
 }
 
 const win = window as Window;
 export default class C implements Channel {
-    id: string;
-    type: string;
-    displayMetadata?: DisplayMetadata;
-    #FSBL: any;
-    constructor(params: any) {
-        this.id = params.id;
-        this.type = params.type;
-        this.displayMetadata = params.displayMetadata;
-        this.#FSBL = win.FSBL || params.FSBL
+  id: string;
+  type: string;
+  displayMetadata?: DisplayMetadata;
+  #FSBL: any;
+  constructor(params: any) {
+    this.id = params.id;
+    this.type = params.type;
+    this.displayMetadata = params.displayMetadata;
+    this.#FSBL = win.FSBL || params.FSBL
+  }
+
+  broadcast(context: object): void {
+    this.#FSBL.Clients.RouterClient.query("FDC3.Channel.broadcast", {
+      source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
+      channel: this.id,
+      context
+    }, () => { });
+  }
+
+  async getCurrentContext(contextType?: string): Promise<object> {
+    const { err, response } = await this.#FSBL.Clients.RouterClient.query("FDC3.Channel.getCurrentContext", {
+      channel: this.id,
+      contextType
+    }, () => { });
+    if (err) {
+      throw (err);
+    } else {
+      return response.data;
+    }
+  }
+
+  addContextListener(handler: ContextHandler): Listener;
+  addContextListener(contextType: string, handler: ContextHandler): Listener;
+  addContextListener(contextTypeOrHandler: string | ContextHandler, handler?: ContextHandler): Listener {
+    let theHandler: ContextHandler = null;
+    let theListenerName: string = null;
+
+    //disambiguate arguments
+    if (typeof contextTypeOrHandler === "string") {
+      theHandler = handler;
+      theListenerName = `FDC3.broadcast.${contextTypeOrHandler}`
+    } else {
+      theHandler = contextTypeOrHandler;
+      theListenerName = `FDC3.broadcast`;
     }
 
-    broadcast(context: object): void {
-        this.#FSBL.Clients.RouterClient.query("FDC3.Channel.broadcast", {
-			source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
-			channel: this.id,
-            context
-        }, () => { });
-    }
-
-    async getCurrentContext(contextType?: string): Promise<object> {
-        const { err, response } = await this.#FSBL.Clients.RouterClient.query("FDC3.Channel.getCurrentContext", {
-            channel: this.id,
-            contextType
-        }, () => { });
-        if (err) {
-            throw (err);
-        } else {
-            return response.data;
+    if (this.id == "global") {
+      const routerHandler: StandardCallback = (err, response) => {
+        //prevent message loops
+        if (response.data.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
+          //delete response.data.source // delete non standard source field we added
+          theHandler(response.data.context);
         }
+      };
+      this.#FSBL.Clients.RouterClient.addListener(theListenerName, routerHandler);
+      return {
+        unsubscribe: () => {
+          this.#FSBL.Clients.RouterClient.removeListener(theListenerName, routerHandler);
+        }
+      }
+    } else {
+      const linkerHandler: StandardCallback = (err, response) => {
+        //prevent message loops
+        if (response.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
+          //delete response.source // delete non standard source field we added
+          theHandler(response.data.context);
+        }
+      };
+      this.#FSBL.Clients.LinkerClient.linkToChannel(this.id, this.#FSBL.Clients.WindowClient.getWindowIdentifier());
+      this.#FSBL.Clients.LinkerClient.subscribe(theListenerName, linkerHandler);
+      return {
+        unsubscribe: () => {
+          this.#FSBL.Clients.LinkerClient.unsubscribe(theListenerName, linkerHandler);
+        }
+      }
     }
-
-    addContextListener(handler: ContextHandler): Listener;
-    addContextListener(contextType: string, handler: ContextHandler): Listener;
-    addContextListener(contextTypeOrHandler: string | ContextHandler, handler?: ContextHandler): Listener {
-		let theHandler: ContextHandler = null;
-		let theListenerName: string = null;
-
-		//disambiguate arguments
-		if (typeof contextTypeOrHandler === "string") {
-			theHandler = handler;
-			theListenerName = `FDC3.broadcast.${contextTypeOrHandler}`
-		} else {
-			theHandler = contextTypeOrHandler;
-			theListenerName = `FDC3.broadcast`;
-		}
-
-		if (this.id == "global") {
-			const routerHandler: StandardCallback = (err, response) => {
-				//prevent message loops
-				if (response.data.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
-					//delete response.data.source // delete non standard source field we added
-					theHandler(response.data);
-				}
-			};
-			this.#FSBL.Clients.RouterClient.addListener(theListenerName, routerHandler);
-			return {
-				unsubscribe: () => {
-					this.#FSBL.Clients.RouterClient.removeListener(theListenerName, routerHandler);
-				}
-			}
-		} else {
-			const linkerHandler: StandardCallback = (err, response) => {
-				//prevent message loops
-				if (response.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
-					//delete response.source // delete non standard source field we added
-					theHandler(response);
-				}
-			};
-			this.#FSBL.Clients.LinkerClient.linkToChannel(this.id, this.#FSBL.Clients.WindowClient.getWindowIdentifier());
-			this.#FSBL.Clients.LinkerClient.subscribe(theListenerName, linkerHandler);
-			return {
-				unsubscribe: () => {
-					this.#FSBL.Clients.LinkerClient.unsubscribe(theListenerName, linkerHandler);
-				}
-			}
-		}
-    }
+  }
 
 }

--- a/src/services/FDC3/channelClient.ts
+++ b/src/services/FDC3/channelClient.ts
@@ -1,87 +1,87 @@
 declare global {
-  interface Window {
-    FSBL: typeof FSBL
-  }
+	interface Window {
+		FSBL: typeof FSBL
+	}
 }
 
 const win = window as Window;
 export default class C implements Channel {
-  id: string;
-  type: string;
-  displayMetadata?: DisplayMetadata;
-  #FSBL: any;
-  constructor(params: any) {
-    this.id = params.id;
-    this.type = params.type;
-    this.displayMetadata = params.displayMetadata;
-    this.#FSBL = win.FSBL || params.FSBL
-  }
+	id: string;
+	type: string;
+	displayMetadata?: DisplayMetadata;
+	#FSBL: any;
+	constructor(params: any) {
+		this.id = params.id;
+		this.type = params.type;
+		this.displayMetadata = params.displayMetadata;
+		this.#FSBL = win.FSBL || params.FSBL
+	}
 
-  broadcast(context: object): void {
-    this.#FSBL.Clients.RouterClient.query("FDC3.Channel.broadcast", {
-      source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
-      channel: this.id,
-      context
-    }, () => { });
-  }
+	broadcast(context: object): void {
+		this.#FSBL.Clients.RouterClient.query("FDC3.Channel.broadcast", {
+			source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
+			channel: this.id,
+			context
+		}, () => { });
+	}
 
-  async getCurrentContext(contextType?: string): Promise<object> {
-    const { err, response } = await this.#FSBL.Clients.RouterClient.query("FDC3.Channel.getCurrentContext", {
-      channel: this.id,
-      contextType
-    }, () => { });
-    if (err) {
-      throw (err);
-    } else {
-      return response.data;
-    }
-  }
+	async getCurrentContext(contextType?: string): Promise<object> {
+		const { err, response } = await this.#FSBL.Clients.RouterClient.query("FDC3.Channel.getCurrentContext", {
+			channel: this.id,
+			contextType
+		}, () => { });
+		if (err) {
+			throw (err);
+		} else {
+			return response.data;
+		}
+	}
 
-  addContextListener(handler: ContextHandler): Listener;
-  addContextListener(contextType: string, handler: ContextHandler): Listener;
-  addContextListener(contextTypeOrHandler: string | ContextHandler, handler?: ContextHandler): Listener {
-    let theHandler: ContextHandler = null;
-    let theListenerName: string = null;
+	addContextListener(handler: ContextHandler): Listener;
+	addContextListener(contextType: string, handler: ContextHandler): Listener;
+	addContextListener(contextTypeOrHandler: string | ContextHandler, handler?: ContextHandler): Listener {
+		let theHandler: ContextHandler = null;
+		let theListenerName: string = null;
 
-    //disambiguate arguments
-    if (typeof contextTypeOrHandler === "string") {
-      theHandler = handler;
-      theListenerName = `FDC3.broadcast.${contextTypeOrHandler}`
-    } else {
-      theHandler = contextTypeOrHandler;
-      theListenerName = `FDC3.broadcast`;
-    }
+		//disambiguate arguments
+		if (typeof contextTypeOrHandler === "string") {
+			theHandler = handler;
+			theListenerName = `FDC3.broadcast.${contextTypeOrHandler}`
+		} else {
+			theHandler = contextTypeOrHandler;
+			theListenerName = `FDC3.broadcast`;
+		}
 
-    if (this.id == "global") {
-      const routerHandler: StandardCallback = (err, response) => {
-        //prevent message loops
-        if (response.data.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
-          //delete response.data.source // delete non standard source field we added
-          theHandler(response.data.context);
-        }
-      };
-      this.#FSBL.Clients.RouterClient.addListener(theListenerName, routerHandler);
-      return {
-        unsubscribe: () => {
-          this.#FSBL.Clients.RouterClient.removeListener(theListenerName, routerHandler);
-        }
-      }
-    } else {
-      const linkerHandler: StandardCallback = (err, response) => {
-        //prevent message loops
-        if (response.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
-          //delete response.source // delete non standard source field we added
-          theHandler(response.data.context);
-        }
-      };
-      this.#FSBL.Clients.LinkerClient.linkToChannel(this.id, this.#FSBL.Clients.WindowClient.getWindowIdentifier());
-      this.#FSBL.Clients.LinkerClient.subscribe(theListenerName, linkerHandler);
-      return {
-        unsubscribe: () => {
-          this.#FSBL.Clients.LinkerClient.unsubscribe(theListenerName, linkerHandler);
-        }
-      }
-    }
-  }
+		if (this.id == "global") {
+			const routerHandler: StandardCallback = (err, response) => {
+				//prevent message loops
+				if (response.data.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
+					//delete response.data.source // delete non standard source field we added
+					theHandler(response.data.context);
+				}
+			};
+			this.#FSBL.Clients.RouterClient.addListener(theListenerName, routerHandler);
+			return {
+				unsubscribe: () => {
+					this.#FSBL.Clients.RouterClient.removeListener(theListenerName, routerHandler);
+				}
+			}
+		} else {
+			const linkerHandler: StandardCallback = (err, response) => {
+				//prevent message loops
+				if (response.source != this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName) {
+					//delete response.source // delete non standard source field we added
+					theHandler(response.data.context);
+				}
+			};
+			this.#FSBL.Clients.LinkerClient.linkToChannel(this.id, this.#FSBL.Clients.WindowClient.getWindowIdentifier());
+			this.#FSBL.Clients.LinkerClient.subscribe(theListenerName, linkerHandler);
+			return {
+				unsubscribe: () => {
+					this.#FSBL.Clients.LinkerClient.unsubscribe(theListenerName, linkerHandler);
+				}
+			}
+		}
+	}
 
 }

--- a/src/services/FDC3/channelClient.ts
+++ b/src/services/FDC3/channelClient.ts
@@ -82,44 +82,6 @@ export default class C implements Channel {
 				}
 			}
 		}
-
-
-
-        if (this.id == "global") {
-            if (typeof contextTypeOrHandler === "string") { // context type specified
-                const routerHandler: StandardCallback = (err, response) => { handler(response.data) };
-                this.#FSBL.Clients.RouterClient.addListener(`FDC3.broadcast.${contextTypeOrHandler}`, routerHandler);
-                return {
-                    unsubscribe: () => {
-                        this.#FSBL.Clients.RouterClient.removeListener(`FDC3.broadcast.${contextTypeOrHandler}`, routerHandler);
-                    }
-                }
-            } else { // context type not specified
-                const routerHandler: StandardCallback = (err, response) => { contextTypeOrHandler(response.data) };
-                this.#FSBL.Clients.RouterClient.addListener(`FDC3.broadcast`, routerHandler);
-                return {
-                    unsubscribe: () => {
-                        this.#FSBL.Clients.RouterClient.removeListener(`FDC3.broadcast`, routerHandler);
-                    }
-                }
-            }
-        }
-        this.#FSBL.Clients.LinkerClient.linkToChannel(this.id, this.#FSBL.Clients.WindowClient.getWindowIdentifier());
-        if (typeof contextTypeOrHandler === "string") { // context type specified
-            this.#FSBL.Clients.LinkerClient.subscribe(`FDC3.broadcast.${contextTypeOrHandler}`, handler);
-            return {
-                unsubscribe: () => {
-                    this.#FSBL.Clients.LinkerClient.unsubscribe(`FDC3.broadcast.${contextTypeOrHandler}`, handler);
-                }
-            }
-        } else { // context type not specified
-            this.#FSBL.Clients.LinkerClient.subscribe(`FDC3.broadcast`, contextTypeOrHandler);
-            return {
-                unsubscribe: () => {
-                    this.#FSBL.Clients.LinkerClient.unsubscribe(`FDC3.broadcast`, contextTypeOrHandler);
-                }
-            }
-        }
     }
 
 }


### PR DESCRIPTION
Watson has been having fun with message loops on FDC3 channels. He's comparing the data in messages received with one's just sent which seems fragile. We could instead add a source field to each message and check it before calling that handler (so no client will process a message it sent). 

The code in this PR is not tested, but provided to illustrate the idea. 
Felt the need to do a little deduplication at the same time, which I think makes it easier to read.