### PR TITLE
Update to the service pattern

### DIFF
--- a/src/services/FDC3/README.MD
+++ b/src/services/FDC3/README.MD
@@ -1,7 +1,9 @@
 # FDC3
+
 Welcome to the Finsemble FDC3 implementation. For those not familiar with FDC3 here is a summary taken from their charter:
->The mission of the Financial Desktop Connectivity and Collaboration Consortium (FDC3) is to develop specific protocols and taxonomies to advance the ability of desktop applications in financial workflows to interoperate in a plug-and-play fashion, without prior bi-lateral agreements.
-They aim to do this by
+
+> The mission of the Financial Desktop Connectivity and Collaboration Consortium (FDC3) is to develop specific protocols and taxonomies to advance the ability of desktop applications in financial workflows to interoperate in a plug-and-play fashion, without prior bi-lateral agreements.
+> They aim to do this by
 
 The FDC3 revolves around a few core concepts; Apps, Intents and Context.
 Apps - These are the applications that participate in FDC3. You can launch these applications and send data.
@@ -9,30 +11,34 @@ Intents - These are the verbs, what you would like to do e.g. _Launch a chart ap
 Context - The noun, this is the data you want to share with other applications, they will in turn use this.
 
 A good example putting all this together looks like this:
->Open (_intent_) a Chart (_app_) and send an instrument (_context_).
+
+> Open (_intent_) a Chart (_app_) and send an instrument (_context_).
 
 The Finsemble FDC3 implementation is comprised of four parts:
+
 - Component Config
 - Preload
 - Client
 - Service
 
 ## Component Config & Preload
+
 The Finsemble config file allows Finsemble to understand that your application is built with FDC3 capability.
 
-
 ### Config Sections:
+
 **Preload:**
 The preload is needed to use the FDC3 Client API, add this to the preload section.
 
 **Toolbar Icon URL:**
-The icon url is used by the intent resolver and will be used to display the logo of the your component. This URL can use the $applicationRoot or can be an external URL. Supported formats: jpg, png, svg
+The icon url is used by the intent resolver and will be used to display the logo of the your component. This URL can use the \$applicationRoot or can be an external URL. Supported formats: jpg, png, svg
 
 **FDC3:**
 This section includes the intents and context that your
- component can accept. See the section **fdc3** in the example below.
+component can accept. See the section **fdc3** in the example below.
 
-  Example:
+Example:
+
 ```
 {
   "FDC3 Component": {
@@ -69,7 +75,76 @@ This section includes the intents and context that your
 <hr/>
 
 ## Service
-The service houses most of the logic for the FDC3 integration support but you will not need knowledge of this section unless you are contributing to the FDC3 Finsemble codebase.
+
+_The service houses most of the logic for the FDC3 integration support but you will not need knowledge of the code unless you are contributing to the FDC3 Finsemble codebase. You are possibly looking for the instructions below on how to add FDC3 to **your** custom service._
+
+### Adding FDC3 to a Service
+
+Step 1: Ensure your service has a config file with a bootDependency of FDC3, here is a config example taken from the testFDC3 component.
+
+```json
+{
+  "comment": "Houses config for any custom services that you'd like to import into Finsemble.",
+  "services": {
+    "testFDC3": {
+      "bootParams": {
+        "stage": "user",
+        "stopOnFailure": false,
+        "autoStart": true,
+        "customFailureMessage": null,
+        "timeout": 10000,
+        "dependencies": ["FDC3"]
+      },
+      "useWindow": true,
+      "active": true,
+      "name": "testFDC3",
+      "file": "$applicationRoot/services/testFDC3/testFDC3Service.js",
+      "visible": false,
+      "html": "$applicationRoot/services/testFDC3/testFDC3.html"
+    }
+  }
+}
+```
+
+Step 2: Import the FDC3 Client by adding this line to the top of your file.
+
+```typescript
+const FDC3Client = require("../FDC3/FDC3Client").default;
+```
+
+Step 3: Next add the fdc3Ready method for the service class like this.
+
+```typescript
+	/**
+	 * Initialize FDC3 - wait for fdc3 to be ready
+	 * @param  {...function} fns - functions to be executed when fdc3 is ready
+	 */
+	fdc3Ready(...fns) {
+		// add any functionality that requires FDC3 in here
+		window.FSBL = {};
+		FSBL.Clients = Finsemble.Clients;
+		this.FDC3Client = new FDC3Client(Finsemble);
+		window.addEventListener("fdc3Ready", () => fns.map(fn => fn()));
+	}
+```
+
+Step 4: Add the fdc3Ready function to the class constructor to bind(this).
+
+```typescript
+this.fdc3Ready = this.fdc3Ready.bind(this);
+```
+
+Step 5: Inside the readyHandler call the fdc3Ready function and pass in any code that relies on FDC3 as a parameter. The fdc3Ready function takes multiple functions as arguments.
+
+```typescript
+	readyHandler(callback) {
+		this.createRouterEndpoints();
+    Finsemble.Clients.Logger.log("TestFDC3 Service ready");
+    // add any functions that rely on fdc3 in the fdc3Ready function below
+		this.fdc3Ready(this.fdc3Example)
+		callback();
+	}
+```
 
 <hr/>
 
@@ -82,7 +157,7 @@ _The FDC3 Client is added in via preload, you now have access to this client as 
 To get started with the API you will need to use the Finsemble FDC3 DesktopAgent -
 `fdc3`
 
-**The code snippets below assume that you prepend the code with the desktop agent code snippet above.*
+\*_The code snippets below assume that you prepend the code with the desktop agent code snippet above._
 
 ### App
 
@@ -104,6 +179,7 @@ To get started with the API you will need to use the Finsemble FDC3 DesktopAgent
 <br/>
 
 ### Context
+
 <table>
 <thead>
 <tr>
@@ -143,6 +219,7 @@ To get started with the API you will need to use the Finsemble FDC3 DesktopAgent
 <br/>
 
 ### Intents
+
 <table>
 <thead>
 <tr>
@@ -190,6 +267,7 @@ context => { //do something here  }
 ### Channel
 
 A channel has this interface:
+
 ```
 interface Channel {
   // properties
@@ -242,17 +320,21 @@ interface Channel {
 ## Example use cases:
 
 ### I know the app I want to open (it's a ChartIQ chart), I also need to send data to the chart, how do I do this?
+
 You can raise an intent. Once the intent has been raised it will show all the apps capable of dealing with your intent in the intent resolver. This works in a similar fashion to your phone when you want to share a link or open a calendar invite and it asks which application you would like to use.
 **Code example: **
 <code>fdc3.raiseIntent('ViewChart')</code>
 
 ### How do my end users use the Channels?
+
 Finsemble allows you to use the Linker Channels. All you need to do is add the preload to your component and Finsemble does the rest.
 
 ### Can I programmatically send data via channels too?
+
 Yes! You can either
 
 ### How do I know what channels I have access to?
+
 System channels (including a global channel) are listed by doing the following:
 
 <code>
@@ -261,12 +343,15 @@ const systemChannels = await fdc3.getSystemChannels();
 </code>
 
 ### Is there a list of default context types?
+
 Yes you can find a list of FDC3 context types here [https://fdc3.finos.org/docs/1.1/context/overview](). FDC3 context types start with "fdc3." .
 
 ### What if the default FDC3 context types don't fit with my data structure?
+
 You will need to create a custom context type. The only value required is the type(see below).
 
-*Note: When broadcasting a custom context type the receiving application will need to know the content and structure of the context you are sending.*
+_Note: When broadcasting a custom context type the receiving application will need to know the content and structure of the context you are sending._
+
 ```
 interface Context {
     type: string;
@@ -277,6 +362,7 @@ interface Context {
     [x: string]: any;
 }
 ```
+
 An example of a finsemble custom type may look like this:
 
 ```

--- a/src/services/testFDC3/config.json
+++ b/src/services/testFDC3/config.json
@@ -2,9 +2,19 @@
   "comment": "Houses config for any custom services that you'd like to import into Finsemble.",
   "services": {
     "testFDC3": {
+      "bootParams": {
+        "stage": "user",
+        "stopOnFailure": false,
+        "autoStart": true,
+        "customFailureMessage": null,
+        "timeout": 10000,
+        "dependencies": [
+          "FDC3"
+        ]
+      },
       "useWindow": true,
       "active": true,
-      "name": "FDC3",
+      "name": "testFDC3",
       "file": "$applicationRoot/services/testFDC3/testFDC3Service.js",
       "visible": false,
       "html": "$applicationRoot/services/testFDC3/testFDC3.html"

--- a/src/services/testFDC3/testFDC3Service.js
+++ b/src/services/testFDC3/testFDC3Service.js
@@ -69,7 +69,7 @@ class testFDC3Service extends Finsemble.baseService {
 		});
 
 		this.readyHandler = this.readyHandler.bind(this);
-		this.setUpFDC3 = this.setUpFDC3.bind(this);
+		this.fdc3Ready = this.fdc3Ready.bind(this);
 		this.onBaseServiceReady(this.readyHandler);
 
 	}
@@ -81,33 +81,21 @@ class testFDC3Service extends Finsemble.baseService {
 	readyHandler(callback) {
 		this.createRouterEndpoints();
 		Finsemble.Clients.Logger.log("TestFDC3 Service ready");
-		this.setUpFDC3()
+		this.fdc3Ready()
 		callback();
 
 	}
 
-	async setUpFDC3() {
-		log("hit FDC3Setup")
-		log(Finsemble.Clients.WindowClient.getWindowIdentifier())
-		try {
-			this.FDC3DesktopAgent = new FDC3Client(Finsemble)
-			this.FDC3 = await this.FDC3DesktopAgent.getOrCreateDesktopAgent('service')
-
-			const FDC3 = this.FDC3
-
-			const channelList = await FDC3.getSystemChannels()
-			log(FDC3)
-			log(channelList)
-			channelList[1].addContextListener((data) => {
-				log('listening to context on ' + channelList[1].id)
-				log(data)
-			})
-		} catch (err) {
-			error(err)
-		}
-
-		await log("complete FDC3Setup")
-
+	/**
+	 * Initialize FDC3 - wait for fdc3 to be ready
+	 * @param  {...function} fns - functions to be executed when fdc3 is ready
+	 */
+	fdc3Ready(...fns) {
+		// add any functionality that requires FDC3 in here
+		window.FSBL = {};
+		FSBL.Clients = Finsemble.Clients;
+		this.FDC3Client = new FDC3Client(Finsemble);
+		window.addEventListener("fdc3Ready", () => fns.map(fn => fn()));
 	}
 	// Implement service functionality
 	myFunction(data) {

--- a/src/services/testFDC3/testFDC3Service.js
+++ b/src/services/testFDC3/testFDC3Service.js
@@ -12,18 +12,16 @@ Finsemble.Clients.Logger.log("TestFDC3 Service starting up");
 // Finsemble.Clients.DistributedStoreClient.initialize();
 // Finsemble.Clients.DragAndDropClient.initialize();
 // Finsemble.Clients.LauncherClient.initialize();
-Finsemble.Clients.LinkerClient.initialize();
+// Finsemble.Clients.LinkerClient.initialize();
 // Finsemble.Clients.HotkeyClient.initialize();
 // Finsemble.Clients.SearchClient.initialize();
 // Finsemble.Clients.StorageClient.initialize();
-Finsemble.Clients.WindowClient.initialize();
+// Finsemble.Clients.WindowClient.initialize();
 // Finsemble.Clients.WorkspaceClient.initialize();
 
 // NOTE: When adding the above clients to a service, be sure to add them to the start up dependencies.
 
-/**
- * TODO: Add service description here
- */
+
 class testFDC3Service extends Finsemble.baseService {
 	/**
 	 * Initializes a new instance of the TestFDC3Service class.
@@ -35,8 +33,7 @@ class testFDC3Service extends Finsemble.baseService {
 				// If the service is using another service directly via an event listener or a responder, that service
 				// should be listed as a service start up dependency.
 				services: [
-					"FDC3",
-					"FDC3Service"
+					// "FDC3"
 					// "assimilationService",
 					// "authenticationService",
 					// "configService",
@@ -59,10 +56,10 @@ class testFDC3Service extends Finsemble.baseService {
 					// "dragAndDropClient",
 					// "hotkeyClient",
 					// "launcherClient",
-					"linkerClient",
+					// "linkerClient",
 					// "searchClient
 					// "storageClient",
-					"windowClient",
+					// "windowClient",
 					// "workspaceClient",
 				]
 			}
@@ -81,9 +78,8 @@ class testFDC3Service extends Finsemble.baseService {
 	readyHandler(callback) {
 		this.createRouterEndpoints();
 		Finsemble.Clients.Logger.log("TestFDC3 Service ready");
-		this.fdc3Ready()
+		this.fdc3Ready(this.fdc3Example)
 		callback();
-
 	}
 
 	/**
@@ -97,6 +93,12 @@ class testFDC3Service extends Finsemble.baseService {
 		this.FDC3Client = new FDC3Client(Finsemble);
 		window.addEventListener("fdc3Ready", () => fns.map(fn => fn()));
 	}
+
+	fdc3Example() {
+		const systemChannels = fdc3.getSystemChannels()
+		console.log(systemChannels)
+	}
+
 	// Implement service functionality
 	myFunction(data) {
 		return `Data passed into query: \n${JSON.stringify(data, null, "\t")}`;


### PR DESCRIPTION
Improved version of the FDC3Test example 

Actioned items:

- Rely on the FDC3 service (must be done via config service manager)
- An actual implementation example on how to use FDC3 in Service Class method (see TestFDC3)
- Docs in the Readme file

Testing: 
1. Open the central logger and find the testFDC3 service. 
2. Open the testFDC3 service console.
2. Look for a promise with an array, in that array should be the system channels.