### PR TITLE
Removing unnecessary query (that has no responder)

### DIFF
--- a/src/services/FDC3/channelClient.ts
+++ b/src/services/FDC3/channelClient.ts
@@ -18,11 +18,6 @@ export default class C implements Channel {
 	}
 
 	broadcast(context: object): void {
-		this.#FSBL.Clients.RouterClient.query(`FDC3.broadcast.${(context as any).type}`, {
-			source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
-			channel: this.id,
-			context
-		}, () => { });
 		this.#FSBL.Clients.RouterClient.query("FDC3.Channel.broadcast", {
 			source: this.#FSBL.Clients.WindowClient.getWindowIdentifier().windowName, //used to prevent message loops
 			channel: this.id,


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/29363/details/
**Description:**
A previous bug fix introduced an unnecessary router query with no responder in FDC3 channel client, which just causes a warning in central logger on context broadcasts.Expected Result:No warnings on context broadcasts

**Steps To Reproduce:**
- Add FDC3 add-on to the seed project
- Add the FDC3 client preload to a component (e.g. Welcome Component):
  ```json
            "component": {
                ...
                "preload": [
                    "$applicationRoot/preloads/FDC3Client.js"
                ],
                ...
  ``
- Run a broadcast from console:
  ```javascript
  fdc3.broadcast({type: "fdc3.instrument", name: "AAPL", id: {ticker: "AMZN"}});
  ```
- Ideally another component should also be listening for this context and be confirmed to receive it
- No extraneous warnings should appear in the central logger.