### PR TITLE
Ensure the client leaves the channel if it is deselected in the linker

### DIFF
--- a/src/services/FDC3/FDC3Client.ts
+++ b/src/services/FDC3/FDC3Client.ts
@@ -74,14 +74,15 @@ class FDC3Client {
 					// Don't do anything if nothing changed (sometimes this event happens twice and causes all channels to be removed)
 					if (linkerChannels.length === 1 && currentChannel && linkerChannels[0] === currentChannel.id) return;
 
-					// remove current channel
-					if (currentChannel) {
-						linkerChannels = linkerChannels.filter(channel => channel !== currentChannel.id);
-					}
-
 					// are we joining a channel or completely leaving channels?
 					if (linkerChannels.length) {
+						// remove current channel
+						if (currentChannel) {
+							linkerChannels = linkerChannels.filter(channel => channel !== currentChannel.id);
+						}
 						await win.fdc3.joinChannel(linkerChannels[0]);
+					} else {
+						await win.fdc3.leaveCurrentChannel();
 					}
 				} else {
 					const linkerChannels = Object.keys(this.#FSBL.Clients.LinkerClient.channels);


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/29385/details/
**Description:**
The FDC3Client doesn't leave the channel when you deselect it from the linker menu and (despite not showing any channels selected) broadcasts to the last selected channel.Expected Result:FDC3Client should leave the channel when its deselected.

**Steps To Reproduce:**
- Spawn two FDC enabled components
- Put both on a channel (e.g. yellow)
- Broadcast context and confirm it is received
- Deselect the channel in the sending component only
- Broadcast context and confirm it is still received (when it should not be)