### PR TITLE
29513 get system channel fix for all channels

### DIFF
--- a/src/services/FDC3/FDC3Client.ts
+++ b/src/services/FDC3/FDC3Client.ts
@@ -19,10 +19,12 @@ class FDC3Client {
 		return new Promise((resolve) => setTimeout(resolve, time));
 	}
 	#FSBL: typeof FSBL;
-	#log: any = console.log; //this.#FSBL.Clients.Logger.log;
+	#log: any;
 
 	constructor(Finsemble?: typeof FSBL) {
 		this.#FSBL = win.FSBL || Finsemble
+		this.#log = this.#FSBL.Clients.Logger.log;
+
 		const setupAgents = async () => {
 			this.#log("FDC3Client: setupAgents");
 			const linkerState = this.#FSBL.Clients.LinkerClient.getState();

--- a/src/services/FDC3/FDC3Service.ts
+++ b/src/services/FDC3/FDC3Service.ts
@@ -117,7 +117,6 @@ class FDC3Service extends BaseService {
 							this.channels[queryMessage.data.channelId] = response;
 							break;
 						case "getSystemChannels":
-							debugger;
 							response = await this.desktopAgent.getSystemChannels();
 							break;
 						case "joinChannel":

--- a/src/services/FDC3/FDC3Service.ts
+++ b/src/services/FDC3/FDC3Service.ts
@@ -7,14 +7,12 @@ const Finsemble = require("@chartiq/finsemble");
 const BaseService = Finsemble.baseService;
 const { RouterClient, LinkerClient, DialogManager, WindowClient, LauncherClient, DistributedStoreClient, Logger } = Finsemble.Clients;
 
-LinkerClient.start(() => { });
 DialogManager.initialize();
 LauncherClient.initialize();
 Logger.start();
 WindowClient.initialize();
 DistributedStoreClient.initialize();
 DialogManager.createStore(() => { });
-
 
 import DesktopAgent from './desktopAgent'
 // const queryJSON = require('./objectQuery/queryJSON.js');
@@ -46,15 +44,19 @@ class FDC3Service extends BaseService {
 	 */
 	async initialize(cb: () => void) {
 		this.createRouterEndpoints();
-		Finsemble.Clients.Logger.log("desktopAgent Service ready");
-		this.desktopAgent = new DesktopAgent({
-			FSBL: Finsemble,
-		})
-		const channels = await this.desktopAgent.getSystemChannels();
-		for (const channel of channels) {
-			this.channels[channel.id] = channel;
-		}
-		cb();
+
+		// Wait for LinkerClient to be started before creating the DesktopAgent
+		LinkerClient.start(async () => {
+			Finsemble.Clients.Logger.log("desktopAgent Service ready");
+			this.desktopAgent = new DesktopAgent({
+				FSBL: Finsemble,
+			})
+			const channels = await this.desktopAgent.getSystemChannels();
+			for (const channel of channels) {
+				this.channels[channel.id] = channel;
+			}
+			cb();
+		});		
 	}
 
 	/**
@@ -115,6 +117,7 @@ class FDC3Service extends BaseService {
 							this.channels[queryMessage.data.channelId] = response;
 							break;
 						case "getSystemChannels":
+							debugger;
 							response = await this.desktopAgent.getSystemChannels();
 							break;
 						case "joinChannel":

--- a/src/services/FDC3/desktopAgentClient.ts
+++ b/src/services/FDC3/desktopAgentClient.ts
@@ -16,14 +16,14 @@ export default class DesktopAgentClient extends EventEmitter implements DesktopA
 	#strict: Boolean;
 	#FDC3Client: any;
 	#FSBL: typeof FSBL;
-	#log: any = console.log; //this.#FSBL.Clients.Logger.log;
+	#log: any;
 
 	constructor(strict: Boolean, FDC3Client: any, Finsemble?: typeof FSBL) {
 		super();
 		this.#strict = strict;
 		this.#FDC3Client = FDC3Client;
 		this.#FSBL = Finsemble;
-
+		this.#log = this.#FSBL.Clients.Logger.log;
 	}
 
 	get isChannelChanging() {


### PR DESCRIPTION
# Description of changes
- Moved the creating of the DesktopAgent into the LinkerClient's `start` callback
- Moved log message to central logger from the console. 

# Testing
1. Reset Finsemble
1. Open Central Logger and filter on "desktopAgent.getSystemChannels"
    - [x] Observe that there are seven channels returned
    ![image](https://user-images.githubusercontent.com/20747430/93392719-460b5f80-f83f-11ea-9dab-a856157ab2f6.png)
1. Open FDC3Tester component
1. Open dev console and run `await fdc3.getSystemChannels()`
    - [x] Observe that seven values are returned
    ![image](https://user-images.githubusercontent.com/20747430/93392940-9f738e80-f83f-11ea-8c32-fc819c1b2e06.png)
