### PR TITLE
add window to intentListener.

### DIFF
--- a/src/components/intentResolver/src/app.tsx
+++ b/src/components/intentResolver/src/app.tsx
@@ -144,7 +144,7 @@ export default function App() {
         const success = err ? false : true
           if (!err) {
             wrap.bringToFront();
-            RouterClient.transmit(`FDC3.intent.${intent.name}`, context);
+            RouterClient.transmit(`FDC3.intent.${intent.name}.${name}`, context);
 
             DialogManager.respondToOpener({ success, intent, context, source, target });
           }

--- a/src/services/FDC3/desktopAgentClient.ts
+++ b/src/services/FDC3/desktopAgentClient.ts
@@ -138,16 +138,18 @@ export default class DesktopAgentClient extends EventEmitter implements DesktopA
 			handler(response.data);
 		}
 
+		const windowName = this.#FSBL.Clients.WindowClient.options.name;
+
 		// deals with data sent at open
 		const spawnData = this.#FSBL.Clients.WindowClient.getSpawnData();
 		if (intent === spawnData?.fdc3?.intent?.name) {
 			handler(spawnData?.fdc3?.context);
 		}
 
-		this.#FSBL.Clients.RouterClient.addListener(`FDC3.intent.${intent}`, routerHandler);
+		this.#FSBL.Clients.RouterClient.addListener(`FDC3.intent.${intent}.${windowName}`, routerHandler);
 		return {
 			unsubscribe: () => {
-				this.#FSBL.Clients.RouterClient.removeListener(`FDC3.intent.${intent}`, routerHandler);
+				this.#FSBL.Clients.RouterClient.removeListener(`FDC3.intent.${intent}.${windowName}`, routerHandler);
 			}
 		}
 	}


### PR DESCRIPTION
Intent resolver was previously sending context to all components that had set up an intentListener but only when sending context to an existing open component, not a newly spawned one.
The fix specifies a window name to restrict which item should receive the intent context when using the Intent Resolver UI to pass context to an open component.

### Example / Steps to test:

1. Open  multiple components with the same intent e.g. **ViewChart**
1. Call `fdc3.raiseIntent("ViewChart", {type:"fdc3.instrument",id:{ticker:"AAA"}})`
1. Intent Resolver UI will open
1. Select a component that is already open using the Intent Resolver
1. The selected component's context should be updated (Symbol on a chart for example) but other components that are listening to **ViewChart** should NOT be updated.

### Checks:

- [ ]  Only the selected component received the updated component ✔
- [ ]  All components context was updated ❌