### PR TITLE
Filter context types passed from spawn data to context listeners

### DIFF
--- a/src/services/FDC3/desktopAgentClient.ts
+++ b/src/services/FDC3/desktopAgentClient.ts
@@ -76,10 +76,10 @@ export default class DesktopAgentClient extends EventEmitter implements DesktopA
 
 		let contextListener = null;
 		if (this.#currentChannel) {
-			if (typeof contextTypeOrHandler === "string") {
+			if (typeof contextTypeOrHandler === "string") { //type of context listener is specified
 				contextListener = this.#currentChannel.addContextListener(contextTypeOrHandler, handler);
-				if (context) handler(context);
-			} else {
+				if (context && contextTypeOrHandler === context?.type) handler(context);
+			} else { //listens to all context types
 				contextListener = this.#currentChannel.addContextListener(contextTypeOrHandler);
 				if (context) contextTypeOrHandler(context);
 			}


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/30969/details/

Context listeners are called on registration if the component was opened with context, we were not checking for a context type match when typed listeners are added with `fdc3.addContextListener(type, handler)`

