### PR TITLE
31011 fix context handlers running on raise intent

### DIFF
--- a/src/components/intentResolver/src/app.tsx
+++ b/src/components/intentResolver/src/app.tsx
@@ -130,7 +130,8 @@ export default function App() {
     const { intent, name, context, componentType } = data
 
     if (action === "spawn") {
-      LauncherClient.spawn(componentType, { data: { fdc3: { intent, context } } }, (err: any, data: any) => {
+      //note use of intentContext to differentiate from data.fdc3.context variable used when passing context on open
+      LauncherClient.spawn(componentType, { data: { fdc3: { intent, intentContext: context } } }, (err: any, data: any) => {
         const success = err ? false : true
 
         DialogManager.respondToOpener({ success, intent, context, source, target })

--- a/src/services/FDC3/desktopAgentClient.ts
+++ b/src/services/FDC3/desktopAgentClient.ts
@@ -143,7 +143,7 @@ export default class DesktopAgentClient extends EventEmitter implements DesktopA
 		// deals with data sent at open
 		const spawnData = this.#FSBL.Clients.WindowClient.getSpawnData();
 		if (intent === spawnData?.fdc3?.intent?.name) {
-			handler(spawnData?.fdc3?.context);
+			handler(spawnData?.fdc3?.intent?.intentContext);
 		}
 
 		this.#FSBL.Clients.RouterClient.addListener(`FDC3.intent.${intent}.${windowName}`, routerHandler);

--- a/src/services/FDC3/desktopAgentClient.ts
+++ b/src/services/FDC3/desktopAgentClient.ts
@@ -142,8 +142,8 @@ export default class DesktopAgentClient extends EventEmitter implements DesktopA
 
 		// deals with data sent at open
 		const spawnData = this.#FSBL.Clients.WindowClient.getSpawnData();
-		if (intent === spawnData?.fdc3?.intent?.name) {
-			handler(spawnData?.fdc3?.intent?.intentContext);
+		if (spawnData?.fdc3?.intentContext) {
+			handler(spawnData?.fdc3?.intentContext);
 		}
 
 		this.#FSBL.Clients.RouterClient.addListener(`FDC3.intent.${intent}.${windowName}`, routerHandler);


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/31011/details/

**Description:**
When the intentResolver spawns a new component it sets `fdc3.context` in its spawn data so that it is available when the component comes up and adds an intent listener. Unfortunately, this same variable is also used by `fdc3.addContextListener()` and `fdc3.open()` - meaning that both the intent and context listeners fire.

**Expected Result:**
- Only the intent listener should fire and not the context listener when a component is spawned via raiseIntent.

**Steps To Reproduce:**
- Create a component with FDC3 support
- When ready, add both an intent and context listener with `fdc3.addContextListener(type, handler)` and `fdc3.addIntentListener(intent, handler)`
- Ensure that the handlers log something so that you can see that they ran
- Add config to the component that defines the intent and context type supported, e.g.: (https://github.com/ChartIQ/finsemble-sales-demo/blob/71f0de75f16a8c4e2e618255b671068055fded80/src/components/chartiq/config.json#L96-L106) 
- Ensure that the type of the context handler you add matches the type you use with the intent
- Spawn the component via raiseIntent(intent, contextObj) and create a new instance
- Review the log and see that both handler ran, when only the intent handler should 