### PR TITLE
31142 fix duplicate apps in intent resolver

### DIFF
--- a/src/services/FDC3/desktopAgent.ts
+++ b/src/services/FDC3/desktopAgent.ts
@@ -99,10 +99,16 @@ export default class D implements DesktopAgent {
 									intent,
 									apps: []
 								}
+								this.appIntents[intent.name].apps.push(appMetadata);
+							} else {
+								//don't add duplicates, replace instead
+								let idx = this.appIntents[intent.name].apps.findIndex((app) => app.name == appMetadata.name);
+								if (idx == -1){
+									this.appIntents[intent.name].apps.push(appMetadata);
+								} else {
+									this.appIntents[intent.name].apps[idx] = appMetadata;
+								}
 							}
-							this.appIntents[intent.name].apps.push(appMetadata);
-
-
 
 							const contexts = intentConfig.contexts;
 							if (contexts && contexts.length) {
@@ -118,9 +124,16 @@ export default class D implements DesktopAgent {
 											intent,
 											apps: []
 										};
+										this.appIntentsContext[context][intent.name].apps.push(appMetadata);
+									} else {
+										//don't add duplicates, replace instead
+										let idx = this.appIntentsContext[context][intent.name].apps.findIndex((app) => app.name == appMetadata.name);
+										if (idx == -1) {
+											this.appIntentsContext[context][intent.name].apps.push(appMetadata);
+										} else {
+											this.appIntentsContext[context][intent.name].apps[idx] = appMetadata;
+										}
 									}
-
-									this.appIntentsContext[context][intent.name].apps.push(appMetadata);
 								}
 							}
 


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/31142/details/
Description:
Each time you add an app from the app catalog, the set of apps in the intent resolver dialog will be duplicated, eventually breaking its UI when they overflow (and don't wrap lines)
![image](https://user-images.githubusercontent.com/1701764/100152116-19587180-2e9a-11eb-8c80-af026ba03c24.png)


**Expected Result:**
Duplicate apps are not created.


**Steps To Reproduce:**
- Setup some components with intents in their configs
- raise the intent with the desktop agent (in a component that has the FDC3Client as a preload): 
  `fdc3.raiseIntent("ViewChart",{ "type": "fdc3.instrument", "id": {"ticker": "TSLA"}});`
- Note which apps are displayed in the intent resolver as options
- Open the advanced launcher and then app catalog
- Add any application to your launcher
- Raise the intent again and note duplicate apps.

