### PR TITLE
31259 remove nonstandard service configd

### DIFF
--- a/src/services/FDC3/config.json
+++ b/src/services/FDC3/config.json
@@ -2,8 +2,6 @@
   "comment": "Houses config for any custom services that you'd like to import into Finsemble.",
   "services": {
     "FDC3": {
-      "useWindow": true,
-      "active": true,
       "name": "FDC3",
       "file": "$applicationRoot/services/FDC3/FDC3Service.js",
       "visible": false,


### PR DESCRIPTION
**Description:**
There are a couple of out-of-date service configs in the FDC3 project that cause schema validation errors: 
![image](https://user-images.githubusercontent.com/1701764/100745293-f9afd480-33d6-11eb-8af1-9237455fb5f4.png)

**Expected Result:**
- No schema validation errors

**Steps To Reproduce:**
- Install the FDC3 add-on with the watch script
- Start Finsemble and check central logger for errors.